### PR TITLE
[feature/ASPHALT-422] update return value to match method return type…

### DIFF
--- a/src/ElasticsearchResponse.php
+++ b/src/ElasticsearchResponse.php
@@ -53,7 +53,7 @@ class ElasticsearchResponse
 
     public function getTotalNumberOfResults() : int
     {
-        return $this->response['hits']['total'] ?? 0;
+        return $this->response['hits']['total']['value'] ?? 0;
     }
 
     /**


### PR DESCRIPTION
turned out that, importing index to updated  AWS_ES_7.4 version has changed the response structure. 
For example. 
1. AWS_ES_6.7 /_search response :
```
... 
"hits" : {
    "total" : 23560,
    "max_score" : 1.0,
    "hits" : [
      {
...
```
2. 1. AWS_ES_7.4 /_search response :
`"hits" : {
    "total" : {
      "value" : 10000,
      "relation" : "gte"
    },
    "max_score" : 1.0,`

PR contains changes avoiding PHP 500 server error. 